### PR TITLE
changed property to ICommand

### DIFF
--- a/XFPINView/BindableProperties/PINView.PINEntryCompletedCommand.cs
+++ b/XFPINView/BindableProperties/PINView.PINEntryCompletedCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Xamarin.Forms;
+using System.Windows.Input;
 
 namespace XFPINView
 {
@@ -7,16 +8,16 @@ namespace XFPINView
         /// <summary>
         /// A Command to Bind and invoked when PIN Entry is completed
         /// </summary>
-        public Command<string> PINEntryCompletedCommand
+        public ICommand PINEntryCompletedCommand
         {
-            get { return (Command<string>)GetValue(PINEntryCompletedCommandProperty); }
+            get { return (ICommand)GetValue(PINEntryCompletedCommandProperty); }
             set { SetValue(PINEntryCompletedCommandProperty, value); }
         }
 
         public static readonly BindableProperty PINEntryCompletedCommandProperty =
            BindableProperty.Create(
               nameof(PINEntryCompletedCommand),
-              typeof(Command<string>),
+              typeof(ICommand),
               typeof(PINView),
               null);
     }


### PR DESCRIPTION
by changing the property type to ICommand, it is possible to use any implementation of Command
e.g
* IAsyncCommand (https://johnthiriet.com/mvvm-going-async-with-async-command/)
* RelayCommand
* Command implementation of MVVM frameworks

so this is more flexible to use

This change doesn't change anything regading the parameter handling. The current pin is still sent to the command handler.